### PR TITLE
controllers: fix instructions params in recipe

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -48,8 +48,11 @@ class RecipesController < ApplicationController
     params.require(:recipe).permit(
       :title,
       :description,
-      :instruction,
       :image,
+      instructions_attributes: [
+        :step,
+        :instruction,
+      ],
       recipe_ingredients_attributes: [
         :id,
         :recipe_id,


### PR DESCRIPTION
parameters to recieve instructions were not properly set. This means it was not possible to add instructions to a recipe.